### PR TITLE
Allow disabling of stretching for the last  items

### DIFF
--- a/ASJCollectionViewFillLayout.podspec
+++ b/ASJCollectionViewFillLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'ASJCollectionViewFillLayout'
-  s.version       = '1.0'
+  s.version       = '1.0.1'
   s.platform	    = :ios, '7.0'
   s.license       = { :type => 'MIT' }
   s.homepage      = 'https://github.com/sudeepjaiswal/ASJCollectionViewFillLayout'

--- a/ASJCollectionViewFillLayout.podspec
+++ b/ASJCollectionViewFillLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'ASJCollectionViewFillLayout'
-  s.version       = '1.0.1'
+  s.version       = '1.1'
   s.platform	    = :ios, '7.0'
   s.license       = { :type => 'MIT' }
   s.homepage      = 'https://github.com/sudeepjaiswal/ASJCollectionViewFillLayout'

--- a/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.h
+++ b/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  If set to NO all items will have the same size, YES stretches them 
  *  across the colleciton view width (default behavior)
  */
-@property (nonatomic, assign) BOOL stretchesLastItems;
+@property (assign, nonatomic) BOOL stretchesLastItems;
 
 @end
 

--- a/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.h
+++ b/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.h
@@ -60,6 +60,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, weak, nonatomic) id<ASJCollectionViewFillLayoutDelegate> delegate;
 
+/**
+ *  Set the stretching behavior for the items in the last "row"
+ *  If set to NO all items will have the same size, YES stretches them 
+ *  across the colleciton view width (default behavior)
+ */
+@property (nonatomic, assign) BOOL stretchesLastItems;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.m
+++ b/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.m
@@ -69,6 +69,7 @@
 {
   self.numberOfItemsInRow = 1;
   self.itemSpacing = 8.0f;
+  self.stretchesLastItems = YES;
 }
 
 #pragma mark - Orientation
@@ -142,7 +143,7 @@
   {
     // calculate item size. extra items will have different widths
     CGSize itemSize = CGSizeZero;
-    if (_extraIndexes.count && [_extraIndexes containsIndex:i])
+    if (self.stretchesLastItems  && _extraIndexes.count && [_extraIndexes containsIndex:i])
     {
       CGFloat availableSpaceForItems = self.collectionView.bounds.size.width - (2 * _itemSpacing) - ((_extraIndexes.count - 1) * _itemSpacing);
       CGFloat itemWidth = availableSpaceForItems / _extraIndexes.count;


### PR DESCRIPTION
Hi,

just added a property that allows the user to the behaviour when stretching the last items would be requires, resulting in all items showing the same size if set to NO. Default is YES, so the previous behaviour does not change.

Cheers,
Oggerschummer
