### PR TITLE
Fix crash if no section available

### DIFF
--- a/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.m
+++ b/ASJCollectionViewFillLayout/ASJCollectionViewFillLayout.m
@@ -296,7 +296,12 @@
 
 - (NSInteger)numberOfItemsInCollectionView
 {
-  return [self.collectionView numberOfItemsInSection:0];
+    if (self.collectionView.numberOfSections >0){
+        return [self.collectionView numberOfItemsInSection:0];
+    }else{
+        //Avoid crash if no sections are available
+        return 0;
+    }
 }
 
 - (CGSize)collectionViewContentSize


### PR DESCRIPTION
Calling numberOfItemsInSection:0 on the collectionView causes a crash in iOS13.
In case there is no section available (e.g. when data is not yet loaded) this fix will avoid the call and return 0